### PR TITLE
Update with subdir field in package files.

### DIFF
--- a/B/Bar/Package.toml
+++ b/B/Bar/Package.toml
@@ -1,3 +1,4 @@
 name = "Bar"
 uuid = "f73876a8-a683-11e9-3353-27bcedd920b0"
 repo = "https://github.com/DilumAluthge/FooBar.git"
+subdir = "otherfolder/subfolder/Bar"

--- a/F/Foo/Package.toml
+++ b/F/Foo/Package.toml
@@ -1,3 +1,4 @@
 name = "Foo"
 uuid = "ac29586c-a683-11e9-2825-255c508e5462"
 repo = "https://github.com/DilumAluthge/FooBar.git"
+subdir = "myfolder/Foo"

--- a/README.md
+++ b/README.md
@@ -38,3 +38,14 @@ $ git cat-file -p a8fc0a42d5b3165ef81bb030a40edc954356a29b
 ```
 
 So the `git-tree-sha1` for `Bar.jl` is `6f4acda473ceb8759c52f8931e7a8db81d727475`.
+
+### Simplified:
+
+```bash
+$ git clone https://github.com/DilumAluthge/FooBar.git
+$ cd FooBar
+$ git rev-parse master:myfolder/Foo
+4cc2b397c52bee060648fade86ea638c53c6fe22
+$ git rev-parse master:otherfolder/subfolder/Bar
+6f4acda473ceb8759c52f8931e7a8db81d727475
+```


### PR DESCRIPTION
Retrofit `subdir` fields into `Package.toml` files to match https://github.com/JuliaRegistries/RegistryTools.jl/pull/31.

Also adds a simpler way to find subdir tree hashes to the README.
